### PR TITLE
Add form tracking option to WordPress plugin settings

### DIFF
--- a/includes/class-usermaven.php
+++ b/includes/class-usermaven.php
@@ -276,6 +276,7 @@ class Usermaven {
 	    }
 	    $custom_domain = get_option('usermaven_custom_domain');
 	    $data_autocapture = get_option('usermaven_autocapture');
+	    $form_tracking = get_option('usermaven_form_tracking');
 	    $cookie_less_tracking = get_option('usermaven_cookie_less_tracking');
 	    $identify_verification = get_option('usermaven_identify_verification');
 	    $is_tracking_enabled = $this->is_tracking_enabled();
@@ -305,6 +306,7 @@ class Usermaven {
                 t.setAttribute('data-tracking-host', '<?php echo esc_attr($tracking_host); ?>');
                 t.setAttribute('data-key', '<?php echo esc_attr($api_key); ?>');
                 <?php if($data_autocapture): ?>t.setAttribute('data-autocapture', 'true');<?php endif; ?>
+                <?php if($form_tracking): ?>t.setAttribute('data-form-tracking', 'true');<?php endif; ?>
                 <?php if($cookie_less_tracking): ?>t.setAttribute('data-privacy-policy', 'strict');<?php endif; ?>
                 t.setAttribute('data-randomize-url', 'true');
                 t.src = '<?php echo esc_attr($tracking_path); ?>';

--- a/includes/usermaven-settings-form.php
+++ b/includes/usermaven-settings-form.php
@@ -14,6 +14,7 @@ function usermaven_activation_form() {
     } else {
       // Get the form data
       $autocapture = isset( $_POST['autocapture'] ) ? true : false;
+      $form_tracking = isset( $_POST['form_tracking'] ) ? true : false;
       $cookie_less_tracking = isset( $_POST['cookie_less_tracking'] ) ? true : false;
       $identify_verification = isset( $_POST['identify_verification'] ) ? true : false;
       $embed_dashboard = isset( $_POST['embed_dashboard'] ) ? true : false;
@@ -63,6 +64,7 @@ function usermaven_activation_form() {
       if (!$error) {
         // Save the form data in the options table
         update_option( 'usermaven_autocapture', $autocapture );
+        update_option( 'usermaven_form_tracking', $form_tracking );
         update_option( 'usermaven_cookie_less_tracking', $cookie_less_tracking );
         update_option( 'usermaven_identify_verification', $identify_verification );
         update_option( 'usermaven_embed_dashboard', $embed_dashboard );
@@ -156,6 +158,10 @@ function usermaven_activation_form() {
         <label for="autocapture">
         <input type="checkbox" name="autocapture" id="autocapture" value="true" <?php checked( get_option('usermaven_autocapture'), true ); ?>>
         Automatically capture frontend events i.e button clicks, form submission etc.</label>
+        <br>
+        <label for="form_tracking">
+        <input type="checkbox" name="form_tracking" id="form_tracking" value="true" <?php checked( get_option('usermaven_form_tracking'), true ); ?>>
+        Track form submissions</label>
         <br>
         <label for="track_woocommerce">
         <input type="checkbox" name="track_woocommerce" id="track_woocommerce" value="true" 


### PR DESCRIPTION
- Added 'Track form submissions' checkbox in Tracking options section
- Saved form_tracking option to usermaven_form_tracking in database
- Integrated form_tracking into tracking snippet to emit data-form-tracking attribute
- Follows same pattern as autocapture and cookie-less tracking options